### PR TITLE
Various suggested changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,38 +59,38 @@ cp target/release/libwaybar_sysinfo.so ~/.local/lib/
 This is the default config
 
 ```css
-.sysinfo-bar {
+#sysinfo .sysinfo-bar {
     padding-left: 5px;
     padding-top: 5px;
     padding-bottom: 5px;
 }
 
 /* progress bar */
-trough {
+#sysinfo trough {
     min-height: 3px;
     min-width: 7px;
     border: none;
 }
 
 /* colored part of progress bar */
-progress {
+#sysinfo progress {
     border: none;
     min-width: 7px;
 }
 
-.cpu progress {
+#sysinfo .cpu progress {
   background-color: #d20f39;
 }
 
-.mem progress {
+#sysinfo .mem progress {
   background-color: #40a02b;
 }
 
-.net progress {
+#sysinfo .net progress {
   background-color: #1e66f5;
 }
 
-.temp progress {
+#sysinfo .temp progress {
   background-color: #df8e1d;
 }
 ```
@@ -99,9 +99,9 @@ Other useful information and examples for styling:
 
 ```css
 /**
- * The whole module is selectable with `.sysinfo`
+ * The whole module is selectable with `#sysinfo`
  */
-.sysinfo {
+#sysinfo {
   background-color: green;
 }
 
@@ -109,7 +109,7 @@ Other useful information and examples for styling:
  * The separate widgets are selectable by their label
  * (beware that this changes if the label is set to a custom value)
  */
-.sysinfo-module.mem, .sysinfo-module.my-custom-network-label {
+#sysinfo .sysinfo-module.mem, #sysinfo .sysinfo-module.my-custom-network-label {
   margin-left: 10px;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -94,3 +94,22 @@ progress {
   background-color: #df8e1d;
 }
 ```
+
+Other useful information and examples for styling:
+
+```css
+/**
+ * The whole module is selectable with `.sysinfo`
+ */
+.sysinfo {
+  background-color: green;
+}
+
+/**
+ * The separate widgets are selectable by their label
+ * (beware that this changes if the label is set to a custom value)
+ */
+.sysinfo-module.mem, .sysinfo-module.my-custom-network-label {
+  margin-left: 10px;
+}
+```

--- a/README.md
+++ b/README.md
@@ -106,10 +106,17 @@ Other useful information and examples for styling:
 }
 
 /**
- * The separate widgets are selectable by their label
+ * The separate widgets are selectable with `.sysinfo-module`
+ */
+#sysinfo .sysinfo-module + .sysinfo-module {
+  margin-left: 10px;
+}
+
+/**
+ * The separate widgets also have a class for their label
  * (beware that this changes if the label is set to a custom value)
  */
-#sysinfo .sysinfo-module.mem, #sysinfo .sysinfo-module.my-custom-network-label {
-  margin-left: 10px;
+#sysinfo .sysinfo-module.cpu progress {
+  background-color: blue;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,17 +32,21 @@ cp target/release/libwaybar_sysinfo.so ~/.local/lib/
     // refresh interval in milliseconds
     "interval_ms": 5000,
     "cpu": {
+        "label": "cpu", // "cpu" is default; you could change this to an icon
         // show most loaded core, avg of all cores or all cores
         "show": ["max_core", "avg_core", "all_cores"]
     },
     "mem": {
+        "label": "ram", // "ram" is default
         "show": ["mem", "swap"]
     },
     "net": {
+        "label": "net", // "net" is default
         // show all networks that match this regexes
         "show": ["eno\\d+", "wlan\\d+"]
     },
     "temp": {
+        "label": "temp", // "temp" is default
         // show sensor with this name. you can see the list by running `sensors`
         "show": ["Core 1"]
         // show max value for each regex

--- a/README.md
+++ b/README.md
@@ -113,10 +113,14 @@ Other useful information and examples for styling:
 }
 
 /**
- * The separate widgets also have a class for their label
- * (beware that this changes if the label is set to a custom value)
+ * The separate widgets also have a class for their type
  */
 #sysinfo .sysinfo-module.cpu progress {
   background-color: blue;
 }
+
+/**
+ * The separate widgets also have a class for their custom label
+ */
+#sysinfo .sysinfo-module.my-label progress { ... }
 ```

--- a/README.md
+++ b/README.md
@@ -123,4 +123,12 @@ Other useful information and examples for styling:
  * The separate widgets also have a class for their custom label
  */
 #sysinfo .sysinfo-module.my-label progress { ... }
+
+/**
+ * Bars are given classes `gte-10`...`gte-90` for how full they are,
+ * allowing colors or other styling to change accordingly
+ */
+#sysinfo .sysinfo-bar.gte-70 progress { background-color: yellow; }
+#sysinfo .sysinfo-bar.gte-80 progress { background-color: orange; }
+#sysinfo .sysinfo-bar.gte-90 progress { background-color: red; }
 ```

--- a/README.md
+++ b/README.md
@@ -48,15 +48,6 @@ cp target/release/libwaybar_sysinfo.so ~/.local/lib/
         // show max value for each regex
         "show_max": ["Core .*"]
     },
-    // please copy this section as is
-    "apps": {
-      "signal": [
-        {
-          "match": "\\([0-9]+\\)$",
-          "class": "unread"
-        }
-      ]
-    },
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,4 +131,17 @@ Other useful information and examples for styling:
 #sysinfo .sysinfo-bar.gte-70 progress { background-color: yellow; }
 #sysinfo .sysinfo-bar.gte-80 progress { background-color: orange; }
 #sysinfo .sysinfo-bar.gte-90 progress { background-color: red; }
+
+/**
+ * Bars might be rounded by default; radius can be adjusted,
+ * separately for `trough` and `progress`
+ */
+#sysinfo trough, #sysinfo progress {
+  border-radius: 0px; /* for no rounding */
+  border-radius: 2px; /* for a fixed radius */
+  border-radius: 1000px; /* or some other high number for as close to circular as possible */
+
+  /* Or you can control the different corners separately */
+  border-top-radius: 1000px 1000px 0px 0px; /* for curved tops and flat bottoms */
+}
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use waybar_cffi::{
     gtk::{
         self, Orientation,
         glib::MainContext,
-        traits::{ContainerExt, StyleContextExt, WidgetExt},
+        traits::{ContainerExt, WidgetExt},
     },
     waybar_module,
 };
@@ -48,7 +48,7 @@ waybar_module!(SysinfoModule);
 fn init(info: &waybar_cffi::InitInfo, config: Config) {
     let root = info.get_root_widget();
     let container = gtk::Box::new(Orientation::Horizontal, 0);
-    container.style_context().add_class("sysinfo");
+    container.set_widget_name("sysinfo");
     root.add(&container);
 
     let context = MainContext::default();

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -50,7 +50,7 @@ impl MeasureCollector {
             let labels = module.labels();
             modules.push(Box::new(module));
 
-            let widget = Widget::new(&cpu_config.label, &labels);
+            let widget = Widget::new("cpu", &cpu_config.label, &labels);
             widgets.push(widget);
         }
         if let Some(ref mem_config) = config.mem {
@@ -58,7 +58,7 @@ impl MeasureCollector {
             let labels = module.labels();
             modules.push(Box::new(module));
 
-            let widget = Widget::new(&mem_config.label, &labels);
+            let widget = Widget::new("mem", &mem_config.label, &labels);
             widgets.push(widget);
         }
         if let Some(ref net_config) = config.net {
@@ -66,7 +66,7 @@ impl MeasureCollector {
             let labels = module.labels();
             modules.push(Box::new(module));
 
-            let widget = Widget::new(&net_config.label, &labels);
+            let widget = Widget::new("net", &net_config.label, &labels);
             widgets.push(widget);
         }
         if let Some(ref temp_config) = config.temp {
@@ -74,7 +74,7 @@ impl MeasureCollector {
             let labels = module.labels();
             modules.push(Box::new(module));
 
-            let widget = Widget::new(&temp_config.label, &labels);
+            let widget = Widget::new("temp", &temp_config.label, &labels);
             widgets.push(widget);
         }
         MeasureCollector {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -64,7 +64,7 @@ thread_local! {
 }
 
 impl Widget {
-    pub fn new(label_str: &str, show_str: &[String]) -> Self {
+    pub fn new(module_str: &str, label_str: &str, show_str: &[String]) -> Self {
         let box_ = gtk::Box::new(gtk::Orientation::Horizontal, 0);
 
         BUTTON_CSS_PROVIDER.with(|provider| {
@@ -72,6 +72,7 @@ impl Widget {
                 .add_provider(provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
 
             box_.style_context().add_class("sysinfo-module");
+            box_.style_context().add_class(module_str);
             box_.style_context().add_class(label_str);
             // TODO: use config.<module>.label
             let label = gtk::Label::new(Some(label_str));

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -71,6 +71,7 @@ impl Widget {
             box_.style_context()
                 .add_provider(provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
 
+            box_.style_context().add_class("sysinfo-module");
             box_.style_context().add_class(label_str);
             // TODO: use config.<module>.label
             let label = gtk::Label::new(Some(label_str));

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -16,38 +16,38 @@ pub struct Widget {
 }
 
 const DEFAULT_CSS: &str = r#"
-.sysinfo-bar {
+#sysinfo .sysinfo-bar {
     padding-left: 5px;
     padding-top: 5px;
     padding-bottom: 5px;
 }
 
 /* progress bar */
-trough {
+#sysinfo trough {
     min-height: 3px;
     min-width: 7px;
     border: none;
 }
 
 /* colored part of progress bar */
-progress {
+#sysinfo progress {
     border: none;
     min-width: 7px;
 }
 
-.cpu progress {
+#sysinfo .cpu progress {
   background-color: #d20f39;
 }
 
-.mem progress {
+#sysinfo .mem progress {
   background-color: #40a02b;
 }
 
-.net progress {
+#sysinfo .net progress {
   background-color: #1e66f5;
 }
 
-.temp progress {
+#sysinfo .temp progress {
   background-color: #df8e1d;
 }
 "#;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -117,6 +117,14 @@ impl Widget {
                 }
                 let bar = &self.bar[i];
                 bar.set_fraction(measure.value / 100.0);
+                for i in (10..100).step_by(10) {
+                    let class_str = format!("gte-{i}");
+                    if measure.value >= i as f64 {
+                        bar.style_context().add_class(&class_str);
+                    } else {
+                        bar.style_context().remove_class(&class_str);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This started off as a list of questions, then I gradually answered them myself and it turned into a list of feature requests and suggestions for documentation improvements, and before I knew it I'd made many of the changes I wanted.

Many of them affect the same areas of code, otherwise I'd open a set of separate pull requests. It's simpler to open it as one batch, but I'm happy to extract certain commits to separate PRs or remove certain changes entirely if you don't like them, or if you want to prescribe exactly which changes you're interested in I can open up a PR for each.

But perhaps you want the whole lot, in which case here's the PR.

### How can I address the whole thing's container in CSS?

Like the built-in "load" module is addressed with `#load`. I tried various things like `#cffi-sysinfo`, `#cffi_sysinfo`, `#cffi\/sysinfo`, `#sysinfo`, `#cffi`, `#waybar-sysinfo`, etc with no luck, before looking at the source code and finding you'd given it a class of `sysinfo`, not an ID.

My use case was that I wanted to style the whole thing in a sort of "tab" widget like the rest of my waybar modules. I also wanted to scope my styles for this module so they can't affect others, like if there were name collisions.

- commit: "Document how to select the module and widgets" -- documenting existing features
- commit: "Set an ID on the module rather than a class". It removes the class, and adds an ID ~~`cffi/sysinfo`~~ `sysinfo` instead, selectable with ~~`#cffi\/sysinfo` (slash needs escaping in CSS). I think this is a reasonable name since it matches the config string, but I'd understand if you'd prefer something else. But I'd urge you to at least accept an ID rather than a class, since this is more consistent with other waybar modules.~~ `#sysinfo`. Note this is potentially breaking, if anyone is relying on the (undocumented until the previous commit) `.sysinfo` selector.

### Can I change the labels for each subwidget?

Eventually looking at the source code I found there's an undocumented configuration option `label` on each.

- commit: "Document the "label" config option"

### But now the default CSS is broken! The class names follow the label.

This is especially weird if using an icon as the label; now I need to use an icon as a class selector too.

- commit: "Add a class to widgets for their type" -- now the classes `cpu`, `mem`, `net`, and `temp` are consistently added for those widget types, whether the labels are customized or not. It still adds a class for the label, too. It's harmless if they're the same.

### Is there a selector for the subwidgets? I know there's `.cpu`, `.mem`, etc by default, but is there a class they all share so I can style all at once?

- commit: "Add a constant class to all widgets" -- now all widgets get a `sysinfo-module` class. This makes it easy to add space between them, or put other styling on each

### Can the bar colours change depending how filled the bar is?

I did a pretty basic solution here. My rationale is that most users are going to have these bars very small and there's probably not much point having a totally continuous resolution for colour changes. I figured every 10% was probably plenty.

- commit: "Set classes on bars depending on fullness" -- this adds/removes `gte-10`, `gte-20`, `gte-30`, ..., `gte-90` classes to the `.sysinfo-bar` element as appropriate

### Can I make the bar corners not rounded?

I figured out how to do this, and thought it might be worth adding some docs for it.

- commit: "Document how to adjust bar rounding"

### Misc:

- commit: "Remove unused config from example" -- looks like you had a copy-paste error from another module you used as a template, perhaps