### PR TITLE
Add nix files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "waybar-sysinfo"
+description = "Plugin for waybar that displays system info as vertical bars"
 version = "0.1.0"
 edition = "2024"
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  manifest = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
+in
+pkgs.rustPlatform.buildRustPackage {
+  pname = manifest.name;
+  version = manifest.version;
+
+  src = pkgs.lib.cleanSource ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+  ];
+  buildInputs = with pkgs; [
+    glib
+    gtk3
+  ];
+
+  meta = {
+    description = manifest.description;
+  };
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771208521,
+        "narHash": "sha256-X01Q3DgSpjeBpapoGA4rzKOn25qdKxbPnxHeMLNoHTU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fa56d7d6de78f5a7f997b0ea2bc6efd5868ad9e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Waybar sysinfo plugin";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = nixpkgs.legacyPackages;
+    in {
+      packages = forAllSystems (system: {
+        default = pkgsFor.${system}.callPackage ./default.nix { };
+      });
+      devShells = forAllSystems (system: {
+        default = pkgsFor.${system}.callPackage ./shell.nix { };
+      });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    cargo
+    pkg-config
+    rustfmt
+  ];
+  buildInputs = with pkgs; [
+    glib
+    gtk3
+  ];
+}


### PR DESCRIPTION
Would you accept merging these?

In case you're not familiar with nix, these files achieve the following for those who use nixos or have nix installed on other systems:

- define dependencies
- define build chain
- define some package meta (in this case actually pulling that from the Cargo.toml file, to which I've added a short description, copied from the github repo)
- make entering a development environment trivial (`nix develop` and you now have all dependencies and are ready to go in a dev shell)
- make producing a build trivial (`nix build` and it'll collect all dependencies, build, and you now have the output in `result/lib/libwaybar_sysinfo.so`)

This would also make packaging the module for nixpkgs easier.

I should mention that I myself am something of a beginner with nix. But these files are doing all the above for me and I'm confident they're a good starting point.