### PR TITLE
Allow boosting low values in "net" output with scaling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,18 @@ cp target/release/libwaybar_sysinfo.so ~/.local/lib/
         // set a floor for the maximum throughput value
         // ("100%" on the bars, automatically adjusted upwards
         // within a sliding window)
-        "floor": 1048576 // in bytes per second, default 5000
+        "floor": 1048576, // in bytes per second, default 5000
+        // set scaling strategy, for example to make small throughput more visible
+        "scaling": {
+            "type": "log_power", // logarithmic relationship raised to a power, given by (log(rate+1)/log(max+1))^exponent
+            "exponent": 4, // higher values accentuate small throughput less
+        }
+        // other scaling options:
+        // "scaling": {
+        //     "type": "power", // exponential relationship given by (rate/max)^exponent
+        //     "exponent": 0.33, // 1 would be the same as "linear"; use values greater than 0 and less than 1 to boost small throughput
+        // }
+        // "scaling": { "type": "linear" } // linear relationship given by rate/max
     },
     "temp": {
         "label": "temp", // "temp" is default

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cp target/release/libwaybar_sysinfo.so ~/.local/lib/
         // set a floor for the maximum throughput value
         // ("100%" on the bars, automatically adjusted upwards
         // within a sliding window)
-        "floor": 1048576, // in bytes per second, default 5000
+        "floor": 1048576, // in bytes per second, default 2097152 (2MB/s)
         // set scaling strategy, for example to make small throughput more visible
         "scaling": {
             "type": "log_power", // logarithmic relationship raised to a power, given by (log(rate+1)/log(max+1))^exponent

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,14 @@ pub struct ConfigMem {
     pub show: Vec<String>,
 }
 
+#[derive(Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ConfigNetScaling {
+    Linear,
+    Power { exponent: f64 },
+    LogPower { exponent: f64 },
+}
+
 #[serde_inline_default]
 #[derive(Deserialize)]
 pub struct ConfigNet {
@@ -37,6 +45,8 @@ pub struct ConfigNet {
     pub label: String,
     pub show: Vec<String>,
     pub floor: Option<u64>,
+    #[serde_inline_default(ConfigNetScaling::LogPower { exponent: 4.0 })]
+    pub scaling: ConfigNetScaling,
 }
 
 #[serde_inline_default]

--- a/src/modules/net.rs
+++ b/src/modules/net.rs
@@ -66,7 +66,7 @@ impl Net {
     pub fn new(config: &ConfigNet) -> Self {
         let networks = sysinfo::Networks::new_with_refreshed_list();
         let last_update = Instant::now();
-        let max_limit = AutoMax::new(config.floor.unwrap_or(5000));
+        let max_limit = AutoMax::new(config.floor.unwrap_or(2 * 1024 * 1024));
 
         // config.show is a vec of regex; transform it into list of dev1_send, dev1_recv, ...
         let labels = config

--- a/src/modules/net.rs
+++ b/src/modules/net.rs
@@ -7,9 +7,25 @@ use humansize::{DECIMAL, format_size};
 use regex::Regex;
 
 use crate::{
-    config::ConfigNet,
+    config::{ConfigNet, ConfigNetScaling},
     measure::{Measure, Measures, SysinfoModule},
 };
+
+impl ConfigNetScaling {
+    fn scale(&self, value: f64, max: f64) -> f64 {
+        if max <= 0.0 {
+            return if value <= 0.0 { 0.0 } else { 1.0 };
+        }
+        let scaled = match self {
+            ConfigNetScaling::Linear => value / max,
+            ConfigNetScaling::Power { exponent } => (value / max).powf(*exponent),
+            ConfigNetScaling::LogPower { exponent } => {
+                ((value + 1.0).ln() / (max + 1.0).ln()).powf(*exponent)
+            }
+        };
+        return scaled.clamp(0.0, 1.0);
+    }
+}
 
 #[derive(Default)]
 struct AutoMax {
@@ -43,6 +59,7 @@ pub struct Net {
     last_update: Instant,
     max_limit: AutoMax,
     labels: Vec<String>,
+    scaling: ConfigNetScaling,
 }
 
 impl Net {
@@ -74,6 +91,7 @@ impl Net {
             last_update,
             max_limit,
             labels,
+            scaling: config.scaling.clone(),
         }
     }
 }
@@ -107,13 +125,13 @@ impl SysinfoModule for Net {
             let measure = measures
                 .entry(dev_send.clone())
                 .or_insert(Measure::new(&dev_send));
-            measure.value = send_per_sec as f64 / max as f64 * 100.0;
+            measure.value = self.scaling.scale(send_per_sec as f64, max as f64) * 100.0;
 
             let dev_recv = dev.to_owned() + "_recv";
             let measure = measures
                 .entry(dev_recv.clone())
                 .or_insert(Measure::new(&dev_recv));
-            measure.value = recv_per_sec as f64 / max as f64 * 100.0;
+            measure.value = self.scaling.scale(recv_per_sec as f64, max as f64) * 100.0;
 
             measure.tooltip = format!(
                 "{dev}: {} in / {} out",


### PR DESCRIPTION
I tried a log approach like iftop does in log mode (see #5) but found a flaw with it. The amount of perceived "boost" is far bigger for a given ratio (speed / max) when the max is larger, to the extent that with the max I wanted to use, I was seeing it scaling to 40% readouts when there were only 500 bytes/sec going in or out.

I explored a couple of other approaches and ended up liking this one best: raising the ratio to a power, i.e. applying a gamma curve. This way you get the same curve for any max/floor value. It also means it can be easily customizable by the user, including setting it to be linear like the previous behaviour by setting it to 1.

0.9 would give a very subtle boost, with the boost getting more pronounced as the gamma approaches 0.

After some experimentation I think 0.25 is a decent default.

Now that this is in place I also increased the default floor to 2MB/s.

See some curves here: https://www.wolframalpha.com/input?i=x%2C+x%5E0.75%2C+x%5E0.5%2C+x%5E0.25%2C+x%5E0.1%2C+ln%28x*5000%29%2Fln%285000%29%2C+ln%28x*262144000%29%2Fln%28262144000%29+for+x+from+0+to+1

As well as the linear and gamma curves on that example, there are two log traces at the end which show how extreme things are with a full log scale with a couple of different maximums.